### PR TITLE
Adding syncRoles to User & Permission Models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php":                  ">=5.6",
         "arcanedev/support":    "~3.15",
-        "arcanesoft/contracts": "~1.3"
+        "arcanesoft/contracts": "~1.4"
     },
     "require-dev": {
         "phpunit/phpcov":       "~2.0|~3.0",

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -244,6 +244,9 @@ class User extends Authenticatable implements UserContract
     /**
      * Check if user is on force deleting.
      *
+     * @deprecated since Laravel v5.3.11
+     * @see https://github.com/laravel/framework/pull/15580
+     *
      * @return bool
      */
     public function isForceDeleting()

--- a/src/Traits/AuthRoleTrait.php
+++ b/src/Traits/AuthRoleTrait.php
@@ -35,6 +35,27 @@ trait AuthRoleTrait
     }
 
     /**
+     * Sync the roles by its slugs.
+     *
+     * @param  array  $slugs
+     * @param  bool   $reload
+     *
+     * @return array
+     */
+    public function syncRoles(array $slugs, $reload = true)
+    {
+        /** @var \Illuminate\Database\Eloquent\Collection $roles */
+        $roles  = app(RoleContract::class)->whereIn('slug', $slugs)->get();
+        $synced = $this->roles()->sync(
+            $roles->pluck('id')->toArray()
+        );
+
+        $this->loadRoles($reload);
+
+        return $synced;
+    }
+
+    /**
      * Detach a role from a user.
      *
      * @param  \Arcanesoft\Contracts\Auth\Models\Role|int  $role

--- a/tests/Models/PermissionTest.php
+++ b/tests/Models/PermissionTest.php
@@ -200,6 +200,37 @@ class PermissionTest extends ModelsTest
     }
 
     /** @test */
+    public function it_can_sync_roles_by_its_slugs()
+    {
+        $permission = Permission::create([
+            'name'        => 'Custom permission',
+            'slug'        => 'permissions.custom',
+            'description' => 'Custom permission description.',
+        ]);
+        $roles = collect([
+            Role::create([
+                'name'        => 'Admin',
+                'description' => 'Admin role descriptions.',
+            ]),
+            Role::create([
+                'name'        => 'Moderator',
+                'description' => 'Moderator role descriptions.',
+            ])
+        ]);
+
+        $this->assertCount(0, $permission->roles);
+
+        $synced = $permission->syncRoles(
+            $roles->pluck('slug')->toArray()
+        );
+
+        $this->assertCount($roles->count(),               $synced['attached']);
+        $this->assertSame($roles->pluck('id')->toArray(), $synced['attached']);
+        $this->assertEmpty($synced['detached']);
+        $this->assertEmpty($synced['updated']);
+    }
+
+    /** @test */
     public function it_can_detach_all_roles()
     {
         $permission    = Permission::create([

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -184,6 +184,33 @@ class UserTest extends ModelsTest
     }
 
     /** @test */
+    public function it_can_sync_roles_by_its_slugs()
+    {
+        $user  = $this->createUser();
+        $roles = collect([
+            Role::create([
+            'name'        => 'Admin',
+            'description' => 'Admin role descriptions.',
+        ]),
+            Role::create([
+            'name'        => 'Moderator',
+            'description' => 'Moderator role descriptions.',
+        ])
+        ]);
+
+        $this->assertCount(0, $user->roles);
+
+        $synced = $user->syncRoles(
+            $roles->pluck('slug')->toArray()
+        );
+
+        $this->assertCount($roles->count(),               $synced['attached']);
+        $this->assertSame($roles->pluck('id')->toArray(), $synced['attached']);
+        $this->assertEmpty($synced['detached']);
+        $this->assertEmpty($synced['updated']);
+    }
+
+    /** @test */
     public function it_can_detach_all_roles()
     {
         $user          = $this->createUser();


### PR DESCRIPTION
The `syncRoles` method allows to sync roles by its `slug` instead of regular role's ids.
